### PR TITLE
added command to set/get bias limits in BiasSpectroscopy

### DIFF
--- a/cmds/commands.json
+++ b/cmds/commands.json
@@ -174,6 +174,32 @@
         "args": [],
         "respTypes": {}
     },
+    "getBiasSpecLimits": {
+        "cmdName": "BiasSpectr.LimitsGet",
+        "argTypes": {},
+        "argValues": {},
+        "args": [],
+        "respTypes": {
+            "Start value (V)": "f",
+            "End value (V)": "f"
+        }
+    },
+    "setBiasSpecLimits": {
+        "cmdName": "BiasSpectr.LimitsSet",
+        "argTypes": {
+            "Start value (V)": "f",
+            "End value (V)": "f"
+        },
+        "argValues": {
+            "Start value (V)": 0,
+            "End value (V)": 1
+        },
+        "args": [
+            "Start value (V)",
+            "End value (V)"
+        ],
+        "respTypes": {}
+    },
     "doScan": {
         "cmdName": "Scan.Action",
         "argTypes": {


### PR DESCRIPTION
Additional functions getBiasSpecLimits and setBiasSpecLimits have been added to commands.json to allow changing the voltage limits of BiasSpectroscopy by Aunis